### PR TITLE
Mapped diagnostic context logging

### DIFF
--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/context/MappedDiagnosticContext.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/context/MappedDiagnosticContext.java
@@ -1,0 +1,62 @@
+/*
+Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+
+*/
+package eu.europa.ec.fisheries.uvms.commons.message.context;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import java.util.Enumeration;
+import java.util.Map;
+
+public class MappedDiagnosticContext {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MappedDiagnosticContext.class);
+
+    public static final String MESSAGE_PROPERTY_PREFIX_MDC = "MDC_";
+
+    public static void addThreadMappedDiagnosticContextToMessageProperties(TextMessage messageToAddMessageProperties) {
+        Map<String, String> mappedDiagnosticContextEntries = MDC.getCopyOfContextMap();
+        if (mappedDiagnosticContextEntries == null) {
+            return;
+        }
+        for (Map.Entry<String, String> mappedDiagnosticContextEntry : mappedDiagnosticContextEntries.entrySet()) {
+            String key = MESSAGE_PROPERTY_PREFIX_MDC + mappedDiagnosticContextEntry.getKey();
+            String traceId = mappedDiagnosticContextEntry.getValue();
+            try {
+                messageToAddMessageProperties.setStringProperty(key, traceId);
+            } catch (Exception e) {
+                LOGGER.warn("Unable to set mapped diagnostic context property key: " + key + " value: " + traceId + "  as message property. Reason: " + e.getMessage());
+            }
+        }
+    }
+
+    public static void addMessagePropertiesToThreadMappedDiagnosticContext(Message message) {
+        try {
+            Enumeration<String> enumeration = (Enumeration<String>) message.getPropertyNames();
+            if (enumeration == null) {
+                return;
+            }
+            while (enumeration.hasMoreElements()) {
+                String prefixedPropertyKeyName = enumeration.nextElement();
+                if (prefixedPropertyKeyName.startsWith(MESSAGE_PROPERTY_PREFIX_MDC)) {
+                    String propertyKeyName = prefixedPropertyKeyName.substring(4);
+                    String propertyKeyValue = message.getStringProperty(prefixedPropertyKeyName);
+                    MDC.put(propertyKeyName, propertyKeyValue);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Unable to add message properties to thread mapped diagnostic context. Reason: " + e.getMessage());
+        }
+    }
+}

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractConsumer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractConsumer.java
@@ -14,6 +14,7 @@ package eu.europa.ec.fisheries.uvms.commons.message.impl;
 
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConsumer;
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageException;
+import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
 import javax.annotation.PostConstruct;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
@@ -63,6 +64,7 @@ public abstract class AbstractConsumer implements MessageConsumer {
 				LOGGER.debug("Message with {} has been successfully received.", correlationId);
 				LOGGER.debug("JMS message received: {} \n Content: {}", receivedMessage, ((TextMessage) receivedMessage).getText());
 			}
+			MappedDiagnosticContext.addMessagePropertiesToThreadMappedDiagnosticContext((TextMessage) receivedMessage);
 			return receivedMessage;
 		} catch (final Exception e) {
 			LOGGER.error("[ Error when retrieving message. ] {}", e.getMessage());

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
@@ -27,6 +27,8 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.DeliveryMode;
 import javax.xml.bind.JAXBException;
+
+import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -69,6 +71,7 @@ public abstract class AbstractProducer implements MessageProducer {
                     message.setStringProperty(entry.getKey(), entry.getValue());
                 }
             }
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(message);
             message.setJMSReplyTo(replyTo);
             message.setText(text);
             producer = session.createProducer(getDestination());
@@ -116,6 +119,7 @@ public abstract class AbstractProducer implements MessageProducer {
             LOGGER.debug("Sending message back to recipient from {} with correlationId {} on queue: {}",moduleName, message.getJMSMessageID(), message.getJMSReplyTo());
             TextMessage response = session.createTextMessage(text);
             response.setJMSCorrelationID(message.getJMSMessageID());
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(response);
             producer = session.createProducer(message.getJMSReplyTo());
             producer.send(response);
         } catch (final JMSException e) {
@@ -137,6 +141,7 @@ public abstract class AbstractProducer implements MessageProducer {
             LOGGER.debug("Sending message back to recipient from  with correlationId {} on queue: {}", message.getJMSMessageID(), message.getJMSReplyTo());
             TextMessage response = session.createTextMessage(text);
             response.setJMSCorrelationID(message.getJMSMessageID());
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(response);
             producer = session.createProducer(message.getJMSReplyTo());
             producer.send(response);
         } catch (final JMSException e) {
@@ -159,6 +164,7 @@ public abstract class AbstractProducer implements MessageProducer {
             LOGGER.debug("Sending message back to recipient from {} with correlationId {} on queue: {}",moduleName, message.getJMSMessageID(), message.getJMSReplyTo());
             TextMessage response = session.createTextMessage(text);
             response.setJMSCorrelationID(message.getJMSMessageID());
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(response);
             producer = session.createProducer(message.getJMSReplyTo());
             producer.send(response);
         } catch (final JMSException e) {
@@ -188,6 +194,7 @@ public abstract class AbstractProducer implements MessageProducer {
             LOGGER.debug("Sending message back to recipient from  with correlationId {} on queue: {}", message.getJMSMessageID(), message.getJMSReplyTo());
             TextMessage response = session.createTextMessage(text);
             response.setJMSCorrelationID(message.getJMSMessageID());
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(response);
             producer = session.createProducer(message.getJMSReplyTo());
             producer.send(response);
         } catch (final JMSException e) {
@@ -210,6 +217,7 @@ public abstract class AbstractProducer implements MessageProducer {
             LOGGER.debug("Sending message back to recipient from  with correlationId {} on queue: {}", message.getJMSMessageID(), message.getJMSReplyTo());
             final TextMessage response = session.createTextMessage();
             response.setText(text);
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(response);
             producer = session.createProducer(message.getJMSReplyTo());
             producer.send(response);
         } catch (JMSException | JAXBException e) {
@@ -245,6 +253,7 @@ public abstract class AbstractProducer implements MessageProducer {
                 message.setJMSCorrelationID(message.getJMSMessageID());
             }
             message.setJMSReplyTo(replyTo);
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(message);
             producer.send(message);
             corrId = message.getJMSMessageID();
         } catch (JMSException e) {
@@ -269,6 +278,7 @@ public abstract class AbstractProducer implements MessageProducer {
             LOGGER.debug("Sending message with correlationId {} on queue: {}", destination);
             final TextMessage message = session.createTextMessage(messageToSend);
             message.setJMSReplyTo(replyTo);
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(message);
             producer.send(message);
             return message.getJMSMessageID();
         } catch (JMSException e) {

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractTopicProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractTopicProducer.java
@@ -21,6 +21,8 @@ import javax.jms.JMSException;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.DeliveryMode;
+
+import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +51,7 @@ public abstract class AbstractTopicProducer {
             LOGGER.debug("Sending message to EventBus...");
             TextMessage message = session.createTextMessage(text);
             message.setStringProperty(SERVICE_NAME, serviceName);
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(message);
             producer = session.createProducer(destination);
             producer.setDeliveryMode(jmsDeliveryMode);
             producer.setTimeToLive(timeToLiveInMillis);
@@ -80,6 +83,7 @@ public abstract class AbstractTopicProducer {
             TextMessage message = session.createTextMessage(text);
             message.setStringProperty(SERVICE_NAME, serviceName);
             message.setJMSReplyTo(replyToDestination);
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(message);
             producer = session.createProducer(destination);
             producer.send(message);
             return message.getJMSMessageID();
@@ -108,6 +112,7 @@ public abstract class AbstractTopicProducer {
             if(StringUtils.isNotEmpty(messageCorrelationId)){
                 message.setJMSCorrelationID(messageCorrelationId);
             }
+            MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(message);
             producer = session.createProducer(destination);
             producer.send(message);
             return message.getJMSMessageID();


### PR DESCRIPTION
The Union commons message library has been extended with Mapped diagnostic context functionality.
The Mapped diagnostic context data (MDC) could be attached to the processing thread of an initiating request message flow.
The JMS message properties will be used to help the MDC data travel between Union modules.
The MDC data property values can be defined in the logging pattern of the logback configuration files.