### PR TITLE
Add option to provide a time to live for sendResponseMessageToSender

### DIFF
--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
@@ -12,11 +12,11 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
 
 package eu.europa.ec.fisheries.uvms.commons.message.api;
 
-import java.util.Map;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.jms.Destination;
 import javax.jms.TextMessage;
+import java.util.Map;
 
 public interface MessageProducer {
 
@@ -32,6 +32,26 @@ public interface MessageProducer {
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     String sendModuleMessageNonPersistent(String text, Destination replyTo, long timeToLiveInMillis) throws MessageException;
 
+
+    /**
+     * Deprecated use sendResponseMessageToSender(...) instead.
+     *
+     * @param message
+     * @param text
+     * @deprecated use sendResponseMessageToSender(...) instead.
+     */
+    @Deprecated
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    void sendModuleResponseMessage(TextMessage message, String text) throws MessageException;
+
+    /**
+     * Deprecated use sendResponseMessageToSender(...) instead.
+     *
+     * @param message
+     * @param text
+     * @deprecated use sendResponseMessageToSender(...) instead.
+     */
+    @Deprecated
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     void sendModuleResponseMessage(TextMessage message, String text, String moduleName);
 
@@ -39,10 +59,11 @@ public interface MessageProducer {
     void sendResponseMessageToSender(TextMessage message, String text) throws MessageException;
 
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    void sendResponseMessageToSender(TextMessage message, String text, String moduleName) throws MessageException;
+    void sendResponseMessageToSender(TextMessage message, String text, long timeToLive) throws MessageException;
 
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    void sendModuleResponseMessage(TextMessage message, String text) throws MessageException;
+    void sendResponseMessageToSender(TextMessage message, String text, String moduleName) throws MessageException;
+
 
 	String getDestinationName();
 

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
@@ -127,6 +127,12 @@ public abstract class AbstractProducer implements MessageProducer {
     @Override
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public void sendResponseMessageToSender(final TextMessage message, final String text) throws MessageException {
+        sendResponseMessageToSender(message, text, Message.DEFAULT_TIME_TO_LIVE);
+    }
+
+    @Override
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void sendResponseMessageToSender(final TextMessage message, final String text, long timeToLive) throws MessageException {
         Connection connection = null;
         Session session = null;
         javax.jms.MessageProducer producer = null;
@@ -138,6 +144,7 @@ public abstract class AbstractProducer implements MessageProducer {
             response.setJMSCorrelationID(message.getJMSMessageID());
             MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(response);
             producer = session.createProducer(message.getJMSReplyTo());
+            producer.setTimeToLive(timeToLive);
             producer.send(response);
         } catch (final JMSException e) {
             LOGGER.error("[ Error when returning request. ] {} {}", e.getMessage(), e.getStackTrace());


### PR DESCRIPTION
Add option to provide a time to live for AbstractProducer.sendResponseMessageToSender.
Also copied over @Deprecated annotation and comments, from the implementation class to the interface, so that this is also clear for people who only have a look at the interface.