### PR TITLE
Avoid sync messages to get stuck or to be put at dlq

### DIFF
--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
@@ -81,4 +81,7 @@ public interface MessageProducer {
 
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     String sendMessageToSpecificQueue(String messageToSend, Destination destination, Destination replyTo, long timeToLiveInMillis) throws MessageException;
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    String sendMessageToSpecificQueue(String messageToSend, Destination destination, Destination replyTo, long timeToLiveInMillis, int deliveryMode) throws MessageException;
 }

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
@@ -62,6 +62,9 @@ public interface MessageProducer {
     void sendResponseMessageToSender(TextMessage message, String text, long timeToLive) throws MessageException;
 
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    void sendResponseMessageToSender(TextMessage message, String text, long timeToLive, int deliveryMode) throws MessageException;
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     void sendResponseMessageToSender(TextMessage message, String text, String moduleName) throws MessageException;
 
 

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
@@ -132,7 +132,7 @@ public abstract class AbstractProducer implements MessageProducer {
 
     @Override
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void sendResponseMessageToSender(final TextMessage message, final String text, long timeToLive) throws MessageException {
+    public void sendResponseMessageToSender(final TextMessage message, final String text, long timeToLive, int deliveryMode) throws MessageException {
         Connection connection = null;
         Session session = null;
         javax.jms.MessageProducer producer = null;
@@ -145,6 +145,7 @@ public abstract class AbstractProducer implements MessageProducer {
             MappedDiagnosticContext.addThreadMappedDiagnosticContextToMessageProperties(response);
             producer = session.createProducer(message.getJMSReplyTo());
             producer.setTimeToLive(timeToLive);
+            producer.setDeliveryMode(deliveryMode);
             producer.send(response);
         } catch (final JMSException e) {
             LOGGER.error("[ Error when returning request. ] {} {}", e.getMessage(), e.getStackTrace());
@@ -152,6 +153,12 @@ public abstract class AbstractProducer implements MessageProducer {
         } finally {
             JMSUtils.disconnectQueue(connection, session, producer);
         }
+    }
+
+    @Override
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void sendResponseMessageToSender(final TextMessage message, final String text, long timeToLive) throws MessageException {
+        sendResponseMessageToSender(message, text, timeToLive, DeliveryMode.PERSISTENT);
     }
 
     @Override


### PR DESCRIPTION
**_Notice: this change does not remove the need to stop doing synchronous calls over JMS. We do need a better synchronous call system, like REST. This change is a bandage, to avoid that queues fill up, for the parties that use this in production. In order to stop the bleeding (=having a more performant and trustworthy system) a bigger change is needed._** 

When sending "synchronous" queries over JMS:

- in case that the response is not sent back in time, we don't want it to be stuck on the queue forever. Synchronous responses that don't get picked up should disappear from the queue after a while. In order to accomplish this, we need to set a **timeToLive**.
- when the AcitveMQ server goes down, synchronous responses should not be retried. By the time that ActiveMQ gets up again, nobody is listening anymore. In order to accomplish that, we need to set the **delivery mode to NON_PERSISTENT**.
- when a time to live is set, and the delivery mode is PERSISTENT, the synchronous message is put on the DLQ. Since there is no use in delivering this message manually, there is **no value of keeping this message in the DLQ** (in our opinion). We would prefer that synchronous messages are non-persistent.

This pull request opens up the possibility to set these properties.

_It should be used for synchronous query messages only. When guaranteed delivery is expected, use the methods with default parameters or set the DeliveryMode and time to live explicitely to PERSISTENT and 0._
