### PR TITLE
MDC REST filter

### DIFF
--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/commons/rest/filter/CrossOriginFilter.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/commons/rest/filter/CrossOriginFilter.java
@@ -11,19 +11,13 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.commons.rest.filter;
 
-import java.io.IOException;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.annotation.WebFilter;
-import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 
 /**
@@ -31,11 +25,11 @@ import org.slf4j.LoggerFactory;
 @WebFilter(asyncSupported = true, urlPatterns = {"/*"})
 public class CrossOriginFilter implements Filter {
 
-    final static Logger LOG = LoggerFactory.getLogger(CrossOriginFilter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CrossOriginFilter.class);
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        LOG.info("Requstfilter starting up!");
+        LOG.debug("Cross origin filter starting up");
     }
 
     @Override
@@ -49,7 +43,7 @@ public class CrossOriginFilter implements Filter {
 
     @Override
     public void destroy() {
-        LOG.info("Requstfilter shuting down!");
+        LOG.debug("Cross origin filter shutting down");
     }
 
 }

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/commons/rest/filter/MDCFilter.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/commons/rest/filter/MDCFilter.java
@@ -1,0 +1,53 @@
+package eu.europa.ec.fisheries.uvms.commons.rest.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import javax.servlet.*;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * This filter ensures you that a request id is set on the MDC context for every incoming REST request.
+ * If one was set already, that value will NOT be overridden.
+ *
+ * Use this filter by adding it to your web.xml config.
+ * Example:
+ * <filter>
+ *     <filter-name>MDCFilter</filter-name>
+ *     <filter-class>eu.europa.ec.fisheries.uvms.commons.rest.filter.MDCFilter</filter-class>
+ * </filter>
+ * <filter-mapping>
+ *     <filter-name>MDCFilter</filter-name>
+ *     <url-pattern>/rest/*</url-pattern>
+ * </filter-mapping>
+ *
+ *
+ * Make sure that your logger logs the MDC's requestId.
+ * Example pattern for Logback: %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %X{requestId} %-5level %logger{40} %X{userId}- %msg%n
+ *
+ */
+public class MDCFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MDCFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        LOG.debug("MDC filter starting up");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+        if (MDC.get("requestId") == null) {
+            MDC.put("requestId", UUID.randomUUID().toString());
+        }
+        chain.doFilter(request, res);
+    }
+
+    @Override
+    public void destroy() {
+        LOG.debug("MDC filter shutting down");
+    }
+
+}


### PR DESCRIPTION
In several modules, an MDC tracer is added for every REST call by adding code to an existing REST filter.
I've added a dedicated MDC Rest filter in commons, which can be used by registering it in your web.xml.