### PR TITLE
Revert "Bump resteasy-multipart-provider from 3.8.1.Final to 4.5.1.Fi…

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-multipart-provider</artifactId>
-            <version>4.5.1.Final</version>	<!-- Upgrading this to 4.x.x causes weird errors in configs rest tests. Handle with care -->
+            <version>3.8.1.Final</version>	<!-- Upgrading this to 4.x.x causes weird errors in configs rest tests. Handle with care -->
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.james</groupId>


### PR DESCRIPTION
…nal"

This reverts commit ae5217bda7307c22ffa18f134411f5e70c4ed3fd.