### PR TITLE
Adding AbstractProducer method to facilitate the processing of manual subscriptions

### DIFF
--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/api/MessageProducer.java
@@ -23,6 +23,8 @@ public interface MessageProducer {
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     String sendModuleMessageWithProps(String text, Destination replyTo, Map<String, String> props) throws MessageException;
 
+    void sendModuleMessageWithPropsSameTx(String text, Map<String, String> props) throws MessageException;
+
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     String sendModuleMessageWithProps(String text, Destination replyTo, Map<String, String> props, int jmsDeliveryMode, long timeToLiveInMillis) throws MessageException;
 

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/commons/message/impl/AbstractProducer.java
@@ -70,6 +70,11 @@ public abstract class AbstractProducer implements MessageProducer {
         return sendModuleMessageWithProps(text, replyTo, props, DeliveryMode.PERSISTENT, 0L);
     }
 
+    @Override
+    public void sendModuleMessageWithPropsSameTx(final String text, Map<String, String> props) throws MessageException {
+        sendMessageWithRetry(text, null, null, props, DeliveryMode.PERSISTENT, 0L, null, null,null, RETRIES);
+    }
+
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public String sendModuleMessageNonPersistent(final String text, final Destination replyTo, final long timeToLiveInMillis) throws MessageException {
         return sendModuleMessageWithProps(text, replyTo, null, DeliveryMode.NON_PERSISTENT, timeToLiveInMillis);


### PR DESCRIPTION
In the context of UNIONVMS-4610 and the manual subscriptions we need to send many JMS messages while saving a new manual subscription to the database. The existing methods operate in a new transaction, leading to the race condition where the message is sent to JMS but the subscription it concerns is not yet saved in the database because the transaction didn't find time to commit. The method added to the `AbstractProducer` sends a message in the same transaction.